### PR TITLE
Enforce https only links with URLValidator with custom schemes

### DIFF
--- a/links/migrations/0001_initial.py
+++ b/links/migrations/0001_initial.py
@@ -2,8 +2,8 @@
 
 from django.conf import settings
 from django.db import migrations, models
-import django.db.models.deletion
 import django.utils.timezone
+import django.core.validators
 
 
 class Migration(migrations.Migration):
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('title', models.CharField(max_length=127)),
                 ('description', models.TextField(blank=True, default='', max_length=1000)),
-                ('url', models.URLField()),
+                ('url', models.URLField(validators=[django.core.validators.URLValidator(schemes=('https',))])),
                 ('source_type', models.CharField(choices=[('YT', 'YouTube'), ('SP', 'Spotify'), ('UN', 'Unknown')], max_length=2)),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),

--- a/links/models/link.py
+++ b/links/models/link.py
@@ -1,8 +1,11 @@
+from django.core import validators
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 
 class Link(models.Model):
+    ALLOWED_SCHEMES = ('https',)
+
     class SourceType(models.TextChoices):
         YOUTUBE = 'YT', _('YouTube')
         SPOTIFY = 'SP', _('Spotify')
@@ -10,7 +13,9 @@ class Link(models.Model):
 
     title = models.CharField(max_length=127)
     description = models.TextField(max_length=1000, blank=True, default='')
-    url = models.URLField()
+    url = models.URLField(
+        validators=[validators.URLValidator(schemes=ALLOWED_SCHEMES)],
+    )
     source_type = models.CharField(choices=SourceType.choices, max_length=2)
     user = models.ForeignKey(
         'accounts.User',

--- a/links/serializers/link.py
+++ b/links/serializers/link.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from django.contrib.auth import get_user_model
+from django.core import validators
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
@@ -52,6 +53,7 @@ class LinkCreateSerializer(serializers.ModelSerializer):
             'updated_at',
         )
         extra_kwargs = {
+            'url': {'validators': [validators.URLValidator(schemes=Link.ALLOWED_SCHEMES)]},
             'source_type': {'read_only': True, 'required': False},
             'user': {'read_only': True, 'required': False},
             'track': {'read_only': True, 'required': False},
@@ -90,6 +92,9 @@ class LinkCreateResultSerializer(LinkCreateSerializer):
     # it's only purpose is for the documentation generation
     # do not use elsewhere
     task_id = serializers.CharField(read_only=True)
+
+    class Meta(LinkCreateSerializer.Meta):
+        fields = LinkCreateSerializer.Meta.fields + ('task_id',)
 
 
 def get_source_type_from_url(url: str) -> Link.SourceType:


### PR DESCRIPTION
Add url validators with strict schemes parameter, update model definition, migrations, tests